### PR TITLE
Fix compilation issues for the nRF52840

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ embedded-io = "0.5.0"
 embedded-io-async = "0.5.0"
 embedded-storage = "0.3.0"
 
+cortex-m = { version = "0.7.6", features = ["critical-section-single-core"] }
 cortex-m-rt = "0.7.3"
 
 embassy-executor = { version = "0.2.0", features = ["arch-cortex-m", "executor-thread", "nightly", "defmt", "integrated-timers", "executor-interrupt"] }

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,36 @@
+//! This build script copies the `memory.x` file from the crate root into
+//! a directory where the linker can always find it at build time.
+//! For many projects this is optional, as the linker always searches the
+//! project root directory -- wherever `Cargo.toml` is. However, if you
+//! are using a workspace or have a more complicated build setup, this
+//! build script becomes required. Additionally, by requesting that
+//! Cargo re-run the build script whenever `memory.x` is changed,
+//! updating `memory.x` ensures a rebuild of the application with the
+//! new memory settings.
+
+use std::env;
+use std::fs::File;
+use std::io::Write;
+use std::path::PathBuf;
+
+fn main() {
+    // Put `memory.x` in our output directory and ensure it's
+    // on the linker search path.
+    let out = &PathBuf::from(env::var_os("OUT_DIR").unwrap());
+    File::create(out.join("memory.x"))
+        .unwrap()
+        .write_all(include_bytes!("memory.x"))
+        .unwrap();
+    println!("cargo:rustc-link-search={}", out.display());
+
+    // By default, Cargo will re-run a build script whenever
+    // any file in the project changes. By specifying `memory.x`
+    // here, we ensure the build script is only re-run when
+    // `memory.x` is changed.
+    println!("cargo:rerun-if-changed=memory.x");
+
+    println!("cargo:rustc-link-arg-bins=--nmagic");
+    println!("cargo:rustc-link-arg-bins=-Tlink.x");
+    println!("cargo:rustc-link-arg-bins=-Tdefmt.x");
+    println!("cargo:rustc-env=DEFMT_LOG=info");
+}

--- a/memory.x
+++ b/memory.x
@@ -1,0 +1,7 @@
+MEMORY
+{
+  /* NOTE 1 K = 1 KiBi = 1024 bytes */
+  /* These values correspond to the NRF52840 with Softdevices S140 7.0.1 */
+  FLASH : ORIGIN = 0x00000000, LENGTH = 1024K
+  RAM : ORIGIN = 0x20000000, LENGTH = 256K
+}

--- a/pre-script.rhai
+++ b/pre-script.rhai
@@ -10,14 +10,14 @@ let targets = #{
         arch: "arm",
         toolchain: "nightly",
         rust_target: "thumbv7em-none-eabihf",
-        probe_chip: "nRF52833xxAA"
+        probe_chip: "nRF52833_xxAA"
     },
 
     nrf52840: #{
         arch: "arm",
         toolchain: "nightly",
         rust_target: "thumbv7em-none-eabihf",
-        probe_chip: "nRF52840xxAA"
+        probe_chip: "nRF52840_xxAA"
     },
 
     stm32h743zi: #{


### PR DESCRIPTION
This pull request addresses several issues that emerged during the compilation process for the nRF52840. While some of the fixes could potentially extend to other chipsets, it's important to note that no testing on these other chipsets has been perfomed.

This PR is marked as a draft due to the limited consideration given to the diverse range of chipsets this template may be applied to.

Regarding the `memory.x` linking script, do you have any specific ideas or preferences for how you'd like to handle it?