### PR TITLE
Add support for nRF9160

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,13 +18,25 @@ embedded-storage = "0.3.1"
 
 cortex-m-rt = "0.7.3"
 
+{% if chip != "nrf9160" -%}
 embassy-executor = { version = "0.6", features = ["task-arena-size-1024", "arch-cortex-m", "executor-thread", "defmt", "integrated-timers", "executor-interrupt"] }
 embassy-sync = { version = "0.6" }
 embassy-time = { version = "0.3", features = ["defmt", "defmt-timestamp-uptime"] }
+{% endif -%}
 
-{% if chip contains "nrf" -%}
+{% if chip contains "nrf52" -%}
 cortex-m = { version = "0.7.6", features = ["critical-section-single-core"] }
 embassy-nrf = { version = "0.2", features = ["defmt", "{{ chip }}", "time-driver-rtc1", "gpiote", "unstable-pac", "time"] }
+{% endif -%}
+
+{% if chip contains "nrf91" -%}
+cortex-m = { version = "0.7.6", features = ["critical-section-single-core"] }
+# Due to embassy-net-nrf91 not yet being published to crates.io we need to use git versions of repos
+embassy-nrf = { git="https://github.com/embassy-rs/embassy.git", features = ["defmt", "nrf9160-s", "time-driver-rtc1", "gpiote", "unstable-pac", "time"] }
+embassy-executor = { git="https://github.com/embassy-rs/embassy.git", features = ["task-arena-size-32768", "arch-cortex-m", "executor-thread", "defmt", "executor-interrupt"] }
+embassy-time = { git="https://github.com/embassy-rs/embassy.git", features = ["defmt", "defmt-timestamp-uptime"] }
+embassy-net-nrf91 = { git="https://github.com/embassy-rs/embassy.git", features = ["defmt"]}
+embassy-net = { git="https://github.com/embassy-rs/embassy.git", features = ["defmt", "tcp", "proto-ipv4", "medium-ip", "dns"] }
 {% endif -%}
 
 {% if chip contains "stm32" -%}

--- a/cargo-generate.toml
+++ b/cargo-generate.toml
@@ -9,5 +9,5 @@ pre = ["pre-script.rhai"]
 type = "string"
 prompt = "Which MCU to target?"
 # TODO: Auto-generate the extended list (i.e. from stm32-data)
-choices = ["rp2040", "nrf52833", "nrf52840", "stm32h743zi", "esp32c3"]
+choices = ["rp2040", "nrf52833", "nrf52840", "nrf9160", "stm32h743zi", "esp32c3"]
 default = "rp2040"

--- a/memory.x
+++ b/memory.x
@@ -5,4 +5,12 @@ MEMORY
 {% endif -%}
   FLASH : ORIGIN = {{ flash_start }}, LENGTH = {{ flash_size }}
   RAM : ORIGIN = {{ ram_start }}, LENGTH = {{ ram_size }}
+{% if chip contains "nrf9160" -%}
+  IPC   : ORIGIN = 0x20000000, LENGTH = 64K
+{% endif -%}
 }
+
+{% if chip contains "nrf9160" -%}
+PROVIDE(__start_ipc = ORIGIN(IPC));
+PROVIDE(__end_ipc   = ORIGIN(IPC) + LENGTH(IPC));
+{% endif -%}

--- a/pre-script.rhai
+++ b/pre-script.rhai
@@ -29,6 +29,16 @@ let targets = #{
         ram_size: "256K"
     },
 
+    nrf9160: #{
+        arch: "arm",
+        rust_target: "thumbv8m.main-none-eabihf",
+        probe_chip: "nRF9160_xxAA",
+    flash_start: "0x00000000",
+        flash_size: "1024K",
+        ram_start: "0x20010000",
+        ram_size: "192K",
+    },
+
     stm32h743zi: #{
         arch: "arm",
         rust_target: "thumbv7em-none-eabihf",


### PR DESCRIPTION
Added the option to create a template project for the nRF9160 device.

The template defaults to using the secure version of the device.
The template pulls `embassy-*` from git as `embassy-net-nrf91` is included in `Cargo.toml` by default as this is most likely desirable for the user and to use `embassy-net-nrf91` one needs to be on the master branch of embassy.