### PR TITLE
Tweaks to the Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,11 @@ version = "0.1.0"
 authors = ["{{authors}}"]
 resolver = "2"
 
+[[bin]]
+name = "{{project-name}}"
+test = false
+bench = false
+
 [dependencies]
 defmt = "0.3"
 defmt-rtt = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,3 +53,13 @@ embassy-stm32 = { version = "0.1", features = ["defmt", "{{ chip }}", "unstable-
 cortex-m = { version = "0.7.6" }
 embassy-rp = { version = "0.3", features = ["defmt", "unstable-pac", "time-driver", "critical-section-impl", "rp2040"] }
 {% endif -%}
+
+[profile.release]
+debug = 2
+lto = true
+opt-level = 'z'
+
+[profile.dev]
+debug = 2
+lto = true
+opt-level = "z"


### PR DESCRIPTION
Just two more tweaks to the default `Cargo.toml` generated by this template:

#### a4e5a5f248d6 ("Disable test and benchmark for binary target")
This is common practice for `#[no_std]` binaries because the test and benchmark harnesses are not available.  Fixes some diagnostic warnings emitted by tools like `rust-analyzer`.

#### 06d4eb879daa ("Preset build profiles")
For embedded projects, it is usually a good idea to use stronger optimization strategies, specifically tailored for small executable size.  Additionally, debug information should also be generated for release builds.

These specific settings were taken from the embassy examples [^1].

[^1]: https://github.com/embassy-rs/embassy/blob/f6532e8f2cd20ed2e63d5c68c2027e959eec30d2/examples/rp/Cargo.toml#L63C1-L71C16