### PR TITLE
actually make `main` divergent; remove vestigial `valid_rp235x_variants`

### DIFF
--- a/pre-script.rhai
+++ b/pre-script.rhai
@@ -87,8 +87,8 @@ let target = variable::get("chip");
 // Collapse RP235x `chip` variants to either:
 //     "rp2350" (typically Pico 2 (w/4MB external flash)) or
 //     "rp2354" (w/2MB on-die flash)
-let valid_rp2350_variants = ["rp2350", "rp2350a", "rp2350b"];
-let valid_rp2354_variants = ["rp2354", "rp2354a", "rp2354b"];
+let valid_rp2350_variants = ["rp2350a", "rp2350b"];
+let valid_rp2354_variants = ["rp2354a", "rp2354b"];
 
 if valid_rp2350_variants.contains(target) {
     target = "rp2350";

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,7 @@ use embassy_time::{Duration, Timer};
 use {defmt_rtt as _, panic_probe as _};
 
 #[embassy_executor::main]
-async fn main(_spawner: Spawner) {
+async fn main(_spawner: Spawner) -> ! {
     {% if chip contains "nrf" -%}
     let _p = embassy_nrf::init(Default::default());
     {% endif -%}


### PR DESCRIPTION
Sorry, somehow lost change to make `main()` divergent and missed removing two vestigial variants.  Code is still correct without this MR, but I felt it better to make a clean contribution.